### PR TITLE
testing adding action

### DIFF
--- a/.github/badge.md
+++ b/.github/badge.md
@@ -1,0 +1,10 @@
+Thanks for contributing to the Greater Good Pledge!  If you'd like to
+put a badge in your repository, you can use this link:
+
+[![https://good-labs.github.io/greater-good-pledge/assets/images/badge.svg](https://good-labs.github.io/greater-good-pledge/assets/images/badge.svg)](https://good-labs.github.io/greater-good-pledge)
+
+When released versions are available, you will optionally be able to specify the
+version. If you have questions, or want to generally engage with the Good Labs
+Community, we are on Gitter:
+
+[![Gitter](https://badges.gitter.im/good-labs/community.svg)](https://gitter.im/good-labs/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,0 +1,12 @@
+workflow "Post Merge Message" {
+  on = "pull_request"
+  resolves = ["post message"]
+}
+
+action "post message" {
+  uses = "vsoch/post-merge-message@master"
+  secrets = ["GITHUB_TOKEN"]
+  env = {
+    POST_MESSAGE = ".github/badge.md"
+  }
+}


### PR DESCRIPTION
This will test a quick GitHub action I created that should run and then present a message to the user when the PR is closed / merged. This might be weird to test in that I'll need to PR / merge a few times to test it out :)

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>