### PR TITLE
remove redundant tagline

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -11,7 +11,7 @@
           <a id="forkme_banner" href="{{ site.repo }}">
               <img src="https://good-labs.github.io/greater-good-pledge/assets/images/badge.svg" class="badge"></a>
           <h1 id="project_title">The Greater Good Pledge</h1>
-          <h2 id="project_tagline">for the greater good</h2>
+          <h2 id="project_tagline"></h2>
         </header>
     </div>
 


### PR DESCRIPTION
I find the tagline marked in blue below redundant:

<img width="1018" alt="Screen Shot 2019-05-01 at 6 14 35 PM" src="https://user-images.githubusercontent.com/21006/57046502-c0cddd80-6c3e-11e9-8621-44daff6e1d68.png">
